### PR TITLE
Default to link's href for use:active path argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,11 @@ import active from 'svelte-spa-router/active'
 </style>
 
 <a href="/hello/user" use:link use:active={'/hello/*', 'active'}>Say hi!</a>
+<a href="/hello/user" use:link use:active>Say hi again!</a>
 ````
 
 The `active` action accepts 2 arguments:
 
-- The first is the path that, when matched, makes the link active. In the example above, we want the link to be active when the route is `/hello/*` (the asterisk matches anything after that). As you can see, this doesn't have to be the same as the path the link points to.
+- The first is the path that, when matched, makes the link active. In the first example above, we want the link to be active when the route is `/hello/*` (the asterisk matches anything after that). As you can see, this doesn't have to be the same as the path the link points to.
+When the first argument is omitted or falsey, it defaults to the path specified in the link's `href` attribute.
 - The second is the name of the CSS class to add. This is optional, and it defaults to `active` if not present.

--- a/active.js
+++ b/active.js
@@ -31,10 +31,17 @@ window.addEventListener('hashchange', () => {
  * Svelte Action for automatically adding the "active" class to elements (links, or any other DOM element) when the current location matches a certain path.
  * 
  * @param {HTMLElement} node - The target node (automatically set by Svelte)
- * @param {string} path - Path expression that makes the link active when matched (must start with '/' or '*')
+ * @param {string} [path] - Path expression that makes the link active when matched (must start with '/' or '*'); default is the link's href
  * @param {string} [className] - CSS class to apply to the element when active; default value is "active"
  */
 export default function active(node, path, className) {
+    if (!path) {
+        path = node.getAttribute('href')
+        if (path[0] === '#') {
+            path = path.substring(1)
+        }
+    }
+
     // Default class name
     if (!className) {
         className = 'active'

--- a/active.js
+++ b/active.js
@@ -35,9 +35,10 @@ window.addEventListener('hashchange', () => {
  * @param {string} [className] - CSS class to apply to the element when active; default value is "active"
  */
 export default function active(node, path, className) {
-    if (!path) {
+    // Path defaults to link target
+    if (!path && node.hasAttribute('href')) {
         path = node.getAttribute('href')
-        if (path[0] === '#') {
+        if (path && path.length > 1 && path.charAt(0) == '#') {
             path = path.substring(1)
         }
     }

--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -2,7 +2,7 @@
 <!-- Navigation links, using the "link" action -->
 <!-- Also, use the "active" action to add the "active" CSS class when the URL matches -->
 <ul>
-    <li><a href="/" use:link use:active={'/', 'active'}>Home</a></li>
+    <li><a href="/" use:link use:active>Home</a></li>
     <li><a href="/hello/svelte" use:link use:active={'/hello/*', 'active'}>Say hi!</a></li>
     <li><a href="/does/not/exist" use:link>Not found</a></li>
 </ul>


### PR DESCRIPTION
I read your documentation and I thought: that `path` argument to the `use:active` modifier is actually unnecessary and should fall back to the path that the link points to :wink:

~~Fair warning: I have not run this code and have thus not tested it. So please, if you are interested in merging this, please test it first if it actually works~~

I have now also changed the example to make use of this change and tested that it works.

All the best!