### PR TITLE
Parse "querystring" from the hash

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,7 +14,7 @@ settings:
   svelte3/ignore-styles: true
   html:
     indent: 0
-    report-bad-indent: warn
+    report-bad-indent: error
     html-extensions:
       - .html
       #- .svelte
@@ -38,7 +38,7 @@ rules:
   no-var:
     - error
   prefer-const:
-    - warn
+    - error
   no-unused-vars:
     - error
     - args: none
@@ -91,15 +91,15 @@ rules:
     - error
     - never
   prefer-arrow-callback:
-    - warn
+    - error
   no-return-await:
     - error
   no-console:
-    - warn
+    - error
   no-nested-ternary:
     - error
   no-unneeded-ternary:
-    - warn
+    - error
   no-unexpected-multiline:
     - error
   lines-around-directive:

--- a/README.md
+++ b/README.md
@@ -177,6 +177,29 @@ import {location} from 'svelte-spa-router'
 <p>The current page is: {$location}</p>
 ````
 
+### Querystring parameters
+
+You can also extract "querystring" parameters from the hash of the page. This isn't the _real_ querystring, as it's located after the `#` character in the URL, but it can be used in a similar way. For example: `#/books?show=authors,titles&order=1`.
+
+When svelte-spa-router finds a "querystring" in the hash, it separates that from the location and returns it as a string in the Svelte store `$querystring`. For example:
+
+````html
+<script>
+import {location, querystring} from 'svelte-spa-router'
+</script>
+<p>The current page is: {$location}</p>
+<p>The querystring is: {$querystring}</p>
+````
+
+With the example above, this would print:
+
+````text
+The current page is: /books
+The querystring is: show=authors,titles&order=1
+````
+
+It's important to note that, to keep this component lightweight, svelte-spa-router **does not parse** the "querystring". If you want to parse the value of `$querystring`, you can use third-party modules such as [qs](https://www.npmjs.com/package/qs) in your application.
+
 ### Highlight active links
 
 svelte-spa-router has built-in support for automatically marking links as "active", with the `use:active` action.

--- a/active.js
+++ b/active.js
@@ -1,11 +1,11 @@
 import regexparam from 'regexparam'
-import {getLocation} from './router.svelte'
+import {loc} from './router.svelte'
 
 // List of nodes to update
 let nodes = []
 
 // Current location
-let location = getLocation()
+let location
 
 // Function that updates all nodes marking the active ones
 function checkActive(el) {
@@ -18,14 +18,14 @@ function checkActive(el) {
     }
 }
 
-// Listener that records the current active hash
-window.addEventListener('hashchange', () => {
-    // Get the updated value for location
-    location = getLocation()
+// Listen to changes in the location
+loc.subscribe((value) => {
+    // Update the location
+    location = value.location + (value.querystring ? '?' + value.querystring : '')
 
     // Update all nodes
     nodes.map(checkActive)
-}, false)
+})
 
 /**
  * Svelte Action for automatically adding the "active" class to elements (links, or any other DOM element) when the current location matches a certain path.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,4 +24,5 @@ steps:
       sleep 5
       npm run test
       kill $SERVER_PID
+      npm run lint
     displayName: 'Run tests'

--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -14,8 +14,15 @@
     <button on:click={() => replace('/wild/replaced')}>Replace current page</button>
 </p>
 
+<!-- Query string -->
+<a href="/hello/svelte?quantity=100" use:link use:active={'/hello/*'}>Querystring args</a>
+
 <!-- Show the current path -->
-<p>Current path: <code id="currentpath">{$location}</code></p>
+<p>
+    Current path: <code id="currentpath">{$location}</code>
+    <br/>
+    Querystring: <code id="currentqs">{$querystring}</code>
+</p>
 
 <!-- Show the router -->
 <Router {routes}/>
@@ -32,7 +39,7 @@
 // Normally, this would be import: `import Router from 'svelte-spa-router'`
 import Router from '../../router.svelte'
 // Import the "link" action and the methods to control history programmatically from the same module, as well as the location store
-import {link, push, pop, replace, location} from '../../router.svelte'
+import {link, push, pop, replace, location, querystring} from '../../router.svelte'
 
 // Import the "active" action
 // Normally, this would be import: `import active from 'svelte-spa-router/active'`

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -18,7 +18,7 @@ module.exports = {
         type: 'mocha',
         options: {
             ui: 'bdd',
-            reporter: 'xunit'
+            reporter: 'list'
         }
     },
 

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -6,6 +6,8 @@ module.exports = {
         'test/'
     ],
 
+    output_folder: 'result',
+
     webdriver: {
         start_process: true,
         server_path: 'node_modules/.bin/chromedriver',
@@ -15,7 +17,8 @@ module.exports = {
     test_runner: {
         type: 'mocha',
         options: {
-            ui: 'bdd'
+            ui: 'bdd',
+            reporter: 'xunit'
         }
     },
 

--- a/router.svelte
+++ b/router.svelte
@@ -2,9 +2,14 @@
 import {readable, derived} from 'svelte/store'
 
 /**
+ * @typedef {Object} Location
+ * @property {string} location - Location (page/view), for example `/book`
+ * @property {string} [querystring] - Querystring from the hash, as a string not parsed
+ */
+/**
  * Returns the current location from the hash.
  *
- * @returns {object}
+ * @returns {Location} Location object
  * @private
  */
 function getLocation() {
@@ -219,7 +224,6 @@ let componentParams = {}
 // Handle hash change events
 // Listen to changes in the $loc store and update the page
 $: {
-    console.log('called', $loc)
     // Find a route matching the location
     component = null
     let i = 0

--- a/test/routing.test.js
+++ b/test/routing.test.js
@@ -32,6 +32,7 @@ describe('<Router> component', () => {
             .waitForElementVisible('h2.routetitle')
             .assert.containsText('h2.routetitle', 'Home!')
             .expect.element('#currentpath').text.to.equal('/')
+        browser.expect.element('#currentqs').text.to.equal('')
 
         // /wild
         browser
@@ -39,6 +40,7 @@ describe('<Router> component', () => {
             .waitForElementVisible('h2.routetitle')
             .assert.containsText('h2.routetitle', 'Wild')
             .expect.element('#currentpath').text.to.equal('/wild')
+        browser.expect.element('#currentqs').text.to.equal('')
 
         // /hello/svelte
         browser
@@ -46,6 +48,7 @@ describe('<Router> component', () => {
             .waitForElementVisible('h2.routetitle')
             .assert.containsText('h2.routetitle', 'Hi there!')
             .expect.element('#currentpath').text.to.equal('/hello/svelte')
+        browser.expect.element('#currentqs').text.to.equal('')
 
         browser.end()
     })
@@ -57,6 +60,7 @@ describe('<Router> component', () => {
             .waitForElementVisible('h2.routetitle')
             .assert.containsText('h2.routetitle', 'Hi there!')
             .expect.element('#currentpath').text.to.equal('/hello/svelte')
+        browser.expect.element('#currentqs').text.to.equal('')
 
         browser.end()
     })
@@ -68,12 +72,14 @@ describe('<Router> component', () => {
             .waitForElementVisible('h2.routetitle')
             .assert.containsText('h2.routetitle', 'Hi there!')
             .expect.element('#currentpath').text.to.equal('/hello/svelte')
+        browser.expect.element('#currentqs').text.to.equal('')
         
         browser
             .refresh(() => {
                 browser.waitForElementVisible('h2.routetitle')
                     .assert.containsText('h2.routetitle', 'Hi there!')
                     .expect.element('#currentpath').text.to.equal('/hello/svelte')
+                browser.expect.element('#currentqs').text.to.equal('')
 
                 browser.end()
             })
@@ -85,6 +91,7 @@ describe('<Router> component', () => {
             .waitForElementVisible('h2.routetitle')
             .assert.containsText('h2.routetitle', 'NotFound')
             .expect.element('#currentpath').text.to.equal('/does/not/exist')
+        browser.expect.element('#currentqs').text.to.equal('')
 
         browser.end()
     })
@@ -217,6 +224,27 @@ describe('<Router> component', () => {
                                 })
                         })
                     })
+            })
+    })
+
+    it('querystring from hash', (browser) => {
+        // /hello/svelte?search=query&sort=0
+        browser
+            .url('http://localhost:5000/#/hello/svelte?search=query&sort=0')
+            .waitForElementVisible('h2.routetitle')
+            .assert.containsText('h2.routetitle', 'Hi there!')
+            .expect.element('#currentpath').text.to.equal('/hello/svelte')
+        browser.expect.element('#currentqs').text.to.equal('search=query&sort=0')
+        
+        // Refresh the page
+        browser
+            .refresh(() => {
+                browser.waitForElementVisible('h2.routetitle')
+                    .assert.containsText('h2.routetitle', 'Hi there!')
+                    .expect.element('#currentpath').text.to.equal('/hello/svelte')
+                browser.expect.element('#currentqs').text.to.equal('search=query&sort=0')
+
+                browser.end()
             })
     })
 })


### PR DESCRIPTION
This PR adds another Svelte store `$querystring` to extract the "querystring" from the URL's fragment, for example `#/books?show=authors,titles&order=1`.

I've also re-factored the router and the active link action so they bind to the Svelte store returning the location rather than adding another event listener to the DOM.

See #5.

Checklist:

- [X] Code
- [X] Documentation
- [X] Sample
- [x] Tests