### PR TITLE
Downgrade http-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "svelte": "router.svelte",
   "scripts": {
     "build-example": "(cd example && npx rollup -c)",
-    "start-example": "npx http-server -p 5000 example/dist",
+    "start-example": "npx http-server@0.9.0 -p 5000 example/dist",
     "eslint": "npx eslint -c .eslintrc.yml --ext .js,.svelte,.html .",
     "lint": "npm run eslint",
     "nightwatch": "npx nightwatch",


### PR DESCRIPTION
First of all, thank you for making a great project. 

Recently, http-server modules often transmit incorrect redirection in some os environments. I was trying to run an example of this project, but in some Windows 10 environments. https://github.com/indexzero/http-server/issues/525

I also experienced an error in my browser (ERR_INVALID_REDIRECT). 
So I want to specify the version used as npx as http-server@0.9.0 in this example.