### PR TITLE
Capitalize Router.svelte for case sensitive FS

### DIFF
--- a/active.js
+++ b/active.js
@@ -1,5 +1,5 @@
 import regexparam from 'regexparam'
-import {loc} from './router.svelte'
+import {loc} from './Router.svelte'
 
 // List of nodes to update
 let nodes = []


### PR DESCRIPTION
When running svelte build on Linux the build fails because this one line is importing 'router.svlete' instead of 'Router.svelte'.  Most likely you're using Mac OSX or Windows which are case preserving but insensitive so everything works until you deploy to Linux.