### PR TITLE
Custom regular expressions for defining route patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ const routes = {
 
 Routes must begin with `/` (or `*` for the catch-all route).
 
+Alternatively, you can also define your routes using custom regular expressions, as explained below.
+
 Note that the order matters! When your users navigate inside the app, the first matching path will determine which route to load. It's important that you leave any "catch-all" route (e.g. a "Page not found" one) at the end.
 
 ### Include the router view
@@ -233,6 +235,44 @@ The `active` action accepts 2 arguments:
 - The first is the path that, when matched, makes the link active. In the first example above, we want the link to be active when the route is `/hello/*` (the asterisk matches anything after that). As you can see, this doesn't have to be the same as the path the link points to.
 When the first argument is omitted or falsey, it defaults to the path specified in the link's `href` attribute.
 - The second is the name of the CSS class to add. This is optional, and it defaults to `active` if not present.
+
+### Define routes with custom regular expressions
+
+Since version 1.2 of svelte-spa-router, it's possible to define routes using custom regular expressions too, allowing for greater flexibility. However, this requires defining routes using a JavaScript Map rather than an object:
+
+````js
+import Home from './routes/Home.svelte'
+import Name from './routes/Name.svelte'
+import NotFound from './routes/NotFound.svelte'
+
+const routes = new Map()
+
+// You can still use strings to define routes
+routes.set('/', Home)
+routes.set('/hello/:first/:last?', Name)
+
+// The keys for the next routes are regular expressions
+// You will very likely always want to start the regular expression with ^
+routes.set(/^\/hola\/(.*)/i, Name)
+routes.set(/^\/buongiorno(\/([a-z]+))/i, Name)
+
+// Catch-all, must be last
+routes.set('*', NotFound)
+````
+
+When you define routes as regular expressions, the params prop is populated with an array with the result of the matches from the regular expression.
+
+For example, with this `Name.svelte` route:
+
+````svelte
+<p>Params is: <code>{JSON.stringify(params)}</code></p>
+<script>
+// You need to define the component prop "params"
+export let params = {}
+</script>
+````
+
+When visiting `#/hola/amigos`, the params prop will be `["/hola/amigos","amigos"]`. This is consistent with the results of [`RegExp.prototype.exec()`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec).
 
 ## Advanced usage
 

--- a/Router.svelte
+++ b/Router.svelte
@@ -252,7 +252,6 @@ $: {
     let i = 0
     while (!component && i < routesList.length) {
         const match = routesList[i].match($loc.location)
-        console.log(match)
         if (match) {
             component = routesList[i].component
             componentParams = match

--- a/Router.svelte
+++ b/Router.svelte
@@ -186,8 +186,11 @@ class RouteItem {
      * @param {SvelteComponent} component - Svelte component for the route
      */
     constructor(path, component) {
-        // Path must start with '/' or '*'
-        if (!path || path.length < 1 || (path.charAt(0) != '/' && path.charAt(0) != '*')) {
+        // Path must be a regular or expression, or a string starting with '/' or '*'
+        if (!path || 
+            (typeof path == 'string' && (path.length < 1 || (path.charAt(0) != '/' && path.charAt(0) != '*'))) ||
+            (typeof path == 'object' && !(path instanceof RegExp))
+        ) {
             throw Error('Invalid value for "path" argument')
         }
 
@@ -214,6 +217,11 @@ class RouteItem {
             return null
         }
 
+        // If the input was a regular expression, this._keys would be false, so return matches as is
+        if (this._keys === false) {
+            return matches
+        }
+
         const out = {}
         let i = 0
         while (i < this._keys.length) {
@@ -223,10 +231,14 @@ class RouteItem {
     }
 }
 
+// We need an iterable: if it's not a Map, use Object.entries
+const routesIterable = (routes instanceof Map) ? routes : Object.entries(routes)
+
 // Set up all routes
-const routesList = Object.keys(routes).map((path) => {
-    return new RouteItem(path, routes[path])
-})
+const routesList = []
+for (const [path, route] of routesIterable) {
+    routesList.push(new RouteItem(path, route))
+}
 
 // Props for the component to render
 let component = null
@@ -240,6 +252,7 @@ $: {
     let i = 0
     while (!component && i < routesList.length) {
         const match = routesList[i].match($loc.location)
+        console.log(match)
         if (match) {
             component = routesList[i].component
             componentParams = match

--- a/example/src/routes.js
+++ b/example/src/routes.js
@@ -1,9 +1,10 @@
 import Home from './routes/Home.svelte'
 import Name from './routes/Name.svelte'
 import Wild from './routes/Wild.svelte'
+import Regex from './routes/Regex.svelte'
 import NotFound from './routes/NotFound.svelte'
 
-export default {
+/*export default {
     // Exact path
     '/': Home,
 
@@ -19,4 +20,28 @@ export default {
 
     // Catch-all, must be last
     '*': NotFound,
-}
+}*/
+
+const routes = new Map()
+
+// Exact path
+routes.set('/', Home)
+
+// Allow children to also signal link activation
+routes.set('/brand', Home)
+
+// Using named parameters, with last being optional
+routes.set('/hello/:first/:last?', Name)
+
+// Wildcard parameter
+routes.set('/wild', Wild)
+routes.set('/wild/*', Wild)
+
+// Regular expressions
+routes.set(/\/regex\/(.*?)/i, Regex)
+routes.set(/\/(pattern|match)/i, Regex)
+
+// Catch-all, must be last
+routes.set('*', NotFound)
+
+export default routes

--- a/example/src/routes.js
+++ b/example/src/routes.js
@@ -4,44 +4,53 @@ import Wild from './routes/Wild.svelte'
 import Regex from './routes/Regex.svelte'
 import NotFound from './routes/NotFound.svelte'
 
-/*export default {
+// Use an object for routes unless we have the "routemap=1" querystring param
+let routes
+const urlParams = new URLSearchParams(window.location.search)
+if (!urlParams.has('routemap')) {
+    // The simples way to define routes is to use a dictionary.
+    // This is a key->value pair in which the key is a string of the path.
+    // The path is passed to regexparam that does some transformations allowing the use of params and wildcards
+    routes = {
+        // Exact path
+        '/': Home,
+    
+        // Allow children to also signal link activation
+        '/brand': Home,
+        
+        // Using named parameters, with last being optional
+        '/hello/:first/:last?': Name,
+    
+        // Wildcard parameter
+        '/wild': Wild,
+        '/wild/*': Wild,
+    
+        // Catch-all, must be last
+        '*': NotFound,
+    }
+}
+else {
+    routes = new Map()
+
     // Exact path
-    '/': Home,
+    routes.set('/', Home)
 
     // Allow children to also signal link activation
-    '/brand': Home,
-    
+    routes.set('/brand', Home)
+
     // Using named parameters, with last being optional
-    '/hello/:first/:last?': Name,
+    routes.set('/hello/:first/:last?', Name)
 
     // Wildcard parameter
-    '/wild': Wild,
-    '/wild/*': Wild,
+    routes.set('/wild', Wild)
+    routes.set('/wild/*', Wild)
+
+    // Regular expressions
+    routes.set(/^\/regex\/(.*)?/i, Regex)
+    routes.set(/^\/(pattern|match)(\/[a-z0-9]+)?/i, Regex)
 
     // Catch-all, must be last
-    '*': NotFound,
-}*/
-
-const routes = new Map()
-
-// Exact path
-routes.set('/', Home)
-
-// Allow children to also signal link activation
-routes.set('/brand', Home)
-
-// Using named parameters, with last being optional
-routes.set('/hello/:first/:last?', Name)
-
-// Wildcard parameter
-routes.set('/wild', Wild)
-routes.set('/wild/*', Wild)
-
-// Regular expressions
-routes.set(/\/regex\/(.*?)/i, Regex)
-routes.set(/\/(pattern|match)/i, Regex)
-
-// Catch-all, must be last
-routes.set('*', NotFound)
+    routes.set('*', NotFound)
+}
 
 export default routes

--- a/example/src/routes/Regex.svelte
+++ b/example/src/routes/Regex.svelte
@@ -1,0 +1,7 @@
+<h2 class="routetitle">Regex route</h2>
+
+<p>Match is: <code id="regexmatch">{JSON.stringify(params)}</code></p>
+
+<script>
+export let params = {}
+</script>

--- a/test/01-routing.test.js
+++ b/test/01-routing.test.js
@@ -2,7 +2,11 @@
 
 const assert = require('assert')
 
-describe('<Router> component', () => {
+describe('<Router> component', function() {
+    // Increase timeouts
+    this.slow(2000)
+    this.timeout(3000)
+
     it('renders on the page', (browser) => {
         browser
             .url('http://localhost:5000')

--- a/test/02-active-action.test.js
+++ b/test/02-active-action.test.js
@@ -2,7 +2,11 @@
 
 const assert = require('assert')
 
-describe('use:active action', () => {
+describe('use:active action', function() {
+    // Increase timeouts
+    this.slow(2000)
+    this.timeout(3000)
+
     it('active link', (browser) => {
         browser
             .url('http://localhost:5000/#/')

--- a/test/03-routing-with-map.test.js
+++ b/test/03-routing-with-map.test.js
@@ -1,7 +1,5 @@
 /*eslint-env mocha */
 
-const assert = require('assert')
-
 describe('<Router> component with routes in a Map', function() {
     // Increase timeouts
     this.slow(2000)

--- a/test/03-routing-with-map.test.js
+++ b/test/03-routing-with-map.test.js
@@ -1,0 +1,98 @@
+/*eslint-env mocha */
+
+const assert = require('assert')
+
+describe('<Router> component with routes in a Map', function() {
+    // Increase timeouts
+    this.slow(2000)
+    this.timeout(3000)
+
+    it('renders on the page', (browser) => {
+        browser
+            .url('http://localhost:5000/?routemap=1')
+            .expect.element('body').to.be.present.before(1000)
+
+        browser
+            .waitForElementVisible('h2.routetitle')
+            .assert.containsText('h2.routetitle', 'Home!')
+
+        browser.end()
+    })
+
+    it('current path appears', (browser) => {
+        browser
+            .url('http://localhost:5000/?routemap=1')
+            .waitForElementVisible('#currentpath')
+            .expect.element('#currentpath').text.to.equal('/')
+
+        browser.end()
+    })
+
+    it('route defined as string', (browser) => {
+        // Main route
+        browser
+            .url('http://localhost:5000/?routemap=1#/')
+            .waitForElementVisible('#currentpath')
+            .waitForElementVisible('h2.routetitle')
+            .assert.containsText('h2.routetitle', 'Home!')
+            .expect.element('#currentpath').text.to.equal('/')
+        browser.expect.element('#currentqs').text.to.equal('')
+
+        // /hello/svelte
+        browser
+            .url('http://localhost:5000/?routemap=1#/hello/svelte')
+            .waitForElementVisible('h2.routetitle')
+            .assert.containsText('h2.routetitle', 'Hi there!')
+            .expect.element('#currentpath').text.to.equal('/hello/svelte')
+        browser.expect.element('#currentqs').text.to.equal('')
+
+        browser.end()
+    })
+
+    it('route defined as RegExp', (browser) => {
+        // /^\/regex\/(.*)?/i
+        browser
+            .url('http://localhost:5000/?routemap=1#/REGEX/1')
+            .waitForElementVisible('#currentpath')
+            .waitForElementVisible('h2.routetitle')
+            .assert.containsText('h2.routetitle', 'Regex route')
+            .expect.element('#currentpath').text.to.equal('/REGEX/1')
+        browser.expect.element('#currentqs').text.to.equal('')
+        browser.expect.element('#regexmatch').text.to.equal('["/REGEX/1","1"]')
+
+        // /^\/(pattern|match)(\/[a-z0-9]+)?/i
+        browser
+            .url('http://localhost:5000/?routemap=1#/Match/hello/world')
+            .waitForElementVisible('h2.routetitle')
+            .assert.containsText('h2.routetitle', 'Regex route')
+            .expect.element('#currentpath').text.to.equal('/Match/hello/world')
+        browser.expect.element('#currentqs').text.to.equal('')
+        // This will end at /hello because /world starts with a slash. Since the regexp doesn't have a $ character, it still matches
+        browser.expect.element('#regexmatch').text.to.equal('["/Match/hello","Match","/hello"]')
+
+        // Should not match
+        browser
+            .url('http://localhost:5000/?routemap=1#/REGEX')
+            .waitForElementVisible('h2.routetitle')
+            .assert.containsText('h2.routetitle', 'NotFound')
+            .expect.element('#currentpath').text.to.equal('/REGEX')
+        browser.expect.element('#currentqs').text.to.equal('')
+
+        browser.end()
+    })
+
+    it('querystring from hash', (browser) => {
+        // /^\/(pattern|match)(\/[a-z0-9]+)?/i with querystring
+        // Should only match ?hello=world and not ?routemap=1
+        browser
+            .url('http://localhost:5000/?routemap=1#/Match/hola?hello=world')
+            .waitForElementVisible('h2.routetitle')
+            .assert.containsText('h2.routetitle', 'Regex route')
+            .expect.element('#currentpath').text.to.equal('/Match/hola')
+        browser.expect.element('#currentqs').text.to.equal('hello=world')
+        browser.expect.element('#regexmatch').text.to.equal('["/Match/hola","Match","/hola"]')
+
+        browser.end()
+    })
+})
+


### PR DESCRIPTION
This PR adds support for defining route patterns using regular expressions.

Because RegExp objects cannot be used as keys in JavaScript objects, added support for defining routes via a Map too.