### PR TITLE
Added function to add pre-conditions to routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,10 @@ When visiting `#/hola/amigos`, the params prop will be `["/hola/amigos","amigos"
 
 Check out the [Advanced Usage](/Advanced%20Usage.md) documentation for using:
 
-- [Route transitions](/Advanced%20Usage.md#route-transitions)
+- [routeLoaded event](/Advanced%20Usage.md#routeloaded-event)
 - [Querystring parsing](/Advanced%20Usage.md#querystring-parsing)
+- [Route pre-conditions](/Advanced%20Usage.md#route-pre-conditions) ("Route guards")
+- [Route transitions](/Advanced%20Usage.md#route-transitions)
 - [Nested routers](/Advanced%20Usage.md#nested-routers)
 - [Route groups](/Advanced%20Usage.md#route-groups)
+- [Async route loading](/Advanced%20Usage.md#async-route-loading)

--- a/Router.svelte
+++ b/Router.svelte
@@ -259,11 +259,12 @@ class RouteItem {
     /**
      * Executes all conditions (if any) to control whether the route can be shown. Conditions are executed in the order they are defined, and if a condition fails, the following ones aren't executed.
      *
+     * @param {Location} loc - Location object
      * @returns {bool} Returns true if all the conditions succeeded
      */
-    checkConditions() {
+    checkConditions(loc) {
         for (let i = 0; i < this.conditions.length; i++) {
-            if (!this.conditions[i]()) {
+            if (!this.conditions[i](loc)) {
                 return false
             }
         }
@@ -311,9 +312,9 @@ $: {
             }
 
             // Check if the route can be loaded - if all conditions succeed
-            if (!routesList[i].checkConditions()) {
+            if (!routesList[i].checkConditions($loc)) {
                 // Trigger an event to notify the user
-                dispatchNextTick('conditionsFail', detail)
+                dispatchNextTick('conditionsFailed', detail)
                 break
             }
             component = routesList[i].component

--- a/Router.svelte
+++ b/Router.svelte
@@ -288,6 +288,14 @@ let componentParams = {}
 // Event dispatcher from Svelte
 const dispatch = createEventDispatcher()
 
+// Just like dispatch, but executes on the next iteration of the event loop
+const dispatchNextTick = (name, detail) => {
+    // Execute this code when the current call stack is complete
+    setTimeout(() => {
+        dispatch(name, detail)
+    }, 0)
+}
+
 // Handle hash change events
 // Listen to changes in the $loc store and update the page
 $: {
@@ -297,20 +305,21 @@ $: {
     while (!component && i < routesList.length) {
         const match = routesList[i].match($loc.location)
         if (match) {
+            const detail = {
+                location: $loc.location,
+                component: routesList[i].component
+            }
+
             // Check if the route can be loaded - if all conditions succeed
             if (!routesList[i].checkConditions()) {
                 // Trigger an event to notify the user
-                // Execute this code when the current call stack is complete
-                setTimeout(() => {
-                    dispatch('conditionsfail', {
-                        location: $loc.location,
-                        component: routesList[i].component
-                    })
-                }, 0)
+                dispatchNextTick('conditionsFail', detail)
                 break
             }
             component = routesList[i].component
             componentParams = match
+
+            dispatchNextTick('routeLoaded', detail)
         }
         i++
     }

--- a/Router.svelte
+++ b/Router.svelte
@@ -6,7 +6,7 @@ import {readable, derived} from 'svelte/store'
 
 export function wrap(route, ...conditions) {
     // Parameter route and each item of conditions must be functions
-    if (!route || typeof route !=='function') {
+    if (!route || typeof route != 'function') {
         throw Error('Invalid parameter route')
     }
     if (conditions && conditions.length) {

--- a/Router.svelte
+++ b/Router.svelte
@@ -259,12 +259,13 @@ class RouteItem {
     /**
      * Executes all conditions (if any) to control whether the route can be shown. Conditions are executed in the order they are defined, and if a condition fails, the following ones aren't executed.
      *
-     * @param {Location} loc - Location object
+     * @param {string} location - Location path
+     * @param {string} querystring - Querystring
      * @returns {bool} Returns true if all the conditions succeeded
      */
-    checkConditions(loc) {
+    checkConditions(location, querystring) {
         for (let i = 0; i < this.conditions.length; i++) {
-            if (!this.conditions[i](loc)) {
+            if (!this.conditions[i](location, querystring)) {
                 return false
             }
         }
@@ -307,12 +308,13 @@ $: {
         const match = routesList[i].match($loc.location)
         if (match) {
             const detail = {
+                component: routesList[i].component.name,
                 location: $loc.location,
-                component: routesList[i].component
+                querystring: $loc.querystring
             }
 
             // Check if the route can be loaded - if all conditions succeed
-            if (!routesList[i].checkConditions($loc)) {
+            if (!routesList[i].checkConditions($loc.location, $loc.querystring)) {
                 // Trigger an event to notify the user
                 dispatchNextTick('conditionsFailed', detail)
                 break

--- a/active.js
+++ b/active.js
@@ -2,7 +2,7 @@ import regexparam from 'regexparam'
 import {loc} from './Router.svelte'
 
 // List of nodes to update
-let nodes = []
+const nodes = []
 
 // Current location
 let location

--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -71,7 +71,7 @@ let logbox = ''
 function conditionsFailed(event) {
     // eslint-disable-next-line no-console
     console.error('Caught event conditionsFailed', event.detail)
-    logbox += 'conditionsFailed - ' + event.detail.component.name + '\n'
+    logbox += 'conditionsFailed - ' + JSON.stringify(event.detail) + '\n'
 
     // Replace the route
     replace('/wild/conditions-failed')
@@ -81,7 +81,7 @@ function conditionsFailed(event) {
 function routeLoaded(event) {
     // eslint-disable-next-line no-console
     console.info('Caught event routeLoaded', event.detail)
-    logbox += 'routeLoaded - ' + event.detail.component.name + '\n'
+    logbox += 'routeLoaded - ' + JSON.stringify(event.detail) + '\n'
 }
 
 let dynamicLinks = [

--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -63,6 +63,7 @@ import routes from './routes'
 
 // Handles the "conditionsfail" dispatched by the router when a component can't be loaded because one of its pre-condition failed
 function conditionsfail(event) {
+    // eslint-disable-next-line no-console
     console.error('Caught event conditionsfail', event.detail)
 }
 

--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -40,6 +40,9 @@
 {/each}
 </ul>
 
+<!-- Used for testing -->
+<div id="logbox">{logbox}</div>
+
 <style>
 /* Style for "active" links; need to mark this :global because the router adds the class directly */
 :global(a.active) {
@@ -61,10 +64,14 @@ import active from '../../active'
 // Import the list of routes
 import routes from './routes'
 
+// Contains logging information used by tests
+let logbox = ''
+
 // Handles the "conditionsFail" event dispatched by the router when a component can't be loaded because one of its pre-condition failed
 function conditionsFail(event) {
     // eslint-disable-next-line no-console
     console.error('Caught event conditionsFail', event.detail)
+    logbox = 'conditionsFail - ' + event.detail.component.name
 
     // Replace the route
     replace('/wild/conditions-failed')
@@ -74,6 +81,7 @@ function conditionsFail(event) {
 function routeLoaded(event) {
     // eslint-disable-next-line no-console
     console.info('Caught event routeLoaded', event.detail)
+    logbox = 'routeLoaded - ' + event.detail.component.name
 }
 
 let dynamicLinks = [

--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -26,7 +26,7 @@
 </p>
 
 <!-- Show the router -->
-<Router {routes}/>
+<Router {routes} on:conditionsfail={conditionsfail} />
 
 <h2>Dynamic links</h2>
 <ul class="navigation-dynamic-links">
@@ -59,6 +59,11 @@ import active from '../../active'
 
 // Import the list of routes
 import routes from './routes'
+
+// Handles the "conditionsfail" dispatched by the router when a component can't be loaded because one of its pre-condition failed
+function conditionsfail(event) {
+    console.error('Caught event conditionsfail', event.detail)
+}
 
 let dynamicLinks = [
     {

--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -26,7 +26,7 @@
 </p>
 
 <!-- Show the router -->
-<Router {routes} on:conditionsfail={conditionsfail} />
+<Router {routes} on:conditionsFail={conditionsFail} on:routeLoaded={routeLoaded} />
 
 <!-- Testing dynamic list of links -->
 <h2>Dynamic links</h2>
@@ -61,10 +61,19 @@ import active from '../../active'
 // Import the list of routes
 import routes from './routes'
 
-// Handles the "conditionsfail" dispatched by the router when a component can't be loaded because one of its pre-condition failed
-function conditionsfail(event) {
+// Handles the "conditionsFail" event dispatched by the router when a component can't be loaded because one of its pre-condition failed
+function conditionsFail(event) {
     // eslint-disable-next-line no-console
-    console.error('Caught event conditionsfail', event.detail)
+    console.error('Caught event conditionsFail', event.detail)
+
+    // Replace the route
+    replace('/wild/conditions-failed')
+}
+
+// Handles the "routeLoaded" event dispatched by the router after a route has been successfully loaded
+function routeLoaded(event) {
+    // eslint-disable-next-line no-console
+    console.info('Caught event routeLoaded', event.detail)
 }
 
 let dynamicLinks = [

--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -28,6 +28,7 @@
 <!-- Show the router -->
 <Router {routes} on:conditionsfail={conditionsfail} />
 
+<!-- Testing dynamic list of links -->
 <h2>Dynamic links</h2>
 <ul class="navigation-dynamic-links">
 {#each dynamicLinks as dl (dl.id)}

--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -26,7 +26,7 @@
 </p>
 
 <!-- Show the router -->
-<Router {routes} on:conditionsFail={conditionsFail} on:routeLoaded={routeLoaded} />
+<Router {routes} on:conditionsFailed={conditionsFailed} on:routeLoaded={routeLoaded} />
 
 <!-- Testing dynamic list of links -->
 <h2>Dynamic links</h2>
@@ -41,7 +41,7 @@
 </ul>
 
 <!-- Used for testing -->
-<div id="logbox">{logbox}</div>
+<pre id="logbox">{logbox}</pre>
 
 <style>
 /* Style for "active" links; need to mark this :global because the router adds the class directly */
@@ -67,11 +67,11 @@ import routes from './routes'
 // Contains logging information used by tests
 let logbox = ''
 
-// Handles the "conditionsFail" event dispatched by the router when a component can't be loaded because one of its pre-condition failed
-function conditionsFail(event) {
+// Handles the "conditionsFailed" event dispatched by the router when a component can't be loaded because one of its pre-condition failed
+function conditionsFailed(event) {
     // eslint-disable-next-line no-console
-    console.error('Caught event conditionsFail', event.detail)
-    logbox = 'conditionsFail - ' + event.detail.component.name
+    console.error('Caught event conditionsFailed', event.detail)
+    logbox += 'conditionsFailed - ' + event.detail.component.name + '\n'
 
     // Replace the route
     replace('/wild/conditions-failed')
@@ -81,7 +81,7 @@ function conditionsFail(event) {
 function routeLoaded(event) {
     // eslint-disable-next-line no-console
     console.info('Caught event routeLoaded', event.detail)
-    logbox = 'routeLoaded - ' + event.detail.component.name
+    logbox += 'routeLoaded - ' + event.detail.component.name + '\n'
 }
 
 let dynamicLinks = [

--- a/example/src/main.js
+++ b/example/src/main.js
@@ -1,5 +1,5 @@
+// Initialize the Svelte app and inject it in the DOM
 import App from './App.svelte'
-
 const app = new App({
     target: document.body
 })

--- a/example/src/routes.js
+++ b/example/src/routes.js
@@ -33,23 +33,24 @@ if (!urlParams.has('routemap')) {
         '/wild': Wild,
         '/wild/*': Wild,
 
-        // This route has a pre-condition function that lets people in only 50% of times (and a second pre-condition that is always true)
+        // This route has a pre-condition function that lets people in only 50% of times, and a second pre-condition that is always true
         '/lucky': wrap(Lucky,
-            (loc) => {
-                // If there's a query-string parameter, override the random choice (tests need to be deterministic)
-                if (loc) {
-                    if (loc.querystring == 'pass=1') {
-                        return true
-                    }
-                    else if (loc.querystring == 'pass=0') {
-                        return false
-                    }
+            (location, querystring) => {
+                // If there's a querystring parameter, override the random choice (tests need to be deterministic)
+                if (querystring == 'pass=1') {
+                    return true
+                }
+                else if (querystring == 'pass=0') {
+                    return false
                 }
                 // Random
                 return (Math.random() > 0.5)
             },
-            (loc) => {
-                // Always returns true
+            (location, querystring) => {
+                // This pre-condition is executed only if the first one succeeded
+                console.log('Pre-condition 2 executed', location, querystring)
+
+                // Always succeed
                 return true
             }
         ),

--- a/example/src/routes.js
+++ b/example/src/routes.js
@@ -1,7 +1,13 @@
+// Import the "wrap" function
+// Normally, this would be import: `import {wrap} from 'svelte-spa-router'`
+import {wrap} from '../../Router.svelte'
+
+// Components
 import Home from './routes/Home.svelte'
 import Name from './routes/Name.svelte'
 import Wild from './routes/Wild.svelte'
 import Regex from './routes/Regex.svelte'
+import Lucky from './routes/Lucky.svelte'
 import NotFound from './routes/NotFound.svelte'
 
 // This demonstrates how to pass routes as a POJO (Plain Old JavaScript Object) or a JS Map
@@ -26,6 +32,16 @@ if (!urlParams.has('routemap')) {
         // Wildcard parameter
         '/wild': Wild,
         '/wild/*': Wild,
+
+        // This route has a pre-condition function that lets people in only 50% of times (and a second pre-condition that is always true)
+        '/lucky': wrap(Lucky,
+            () => {
+                return (Math.random() > 0.5)
+            },
+            () => {
+                return true
+            }
+        ),
     
         // Catch-all, must be last
         '*': NotFound,
@@ -46,6 +62,9 @@ else {
     // Wildcard parameter
     routes.set('/wild', Wild)
     routes.set('/wild/*', Wild)
+
+    // This route has a "beforeRoute" function that lets people in only 50% of times
+    routes.set('/lucky', BeforeHook)
 
     // Regular expressions
     routes.set(/^\/regex\/(.*)?/i, Regex)

--- a/example/src/routes.js
+++ b/example/src/routes.js
@@ -63,8 +63,15 @@ else {
     routes.set('/wild', Wild)
     routes.set('/wild/*', Wild)
 
-    // This route has a "beforeRoute" function that lets people in only 50% of times
-    routes.set('/lucky', BeforeHook)
+    // This route has a pre-condition function that lets people in only 50% of times (and a second pre-condition that is always true)
+    routes.set('/lucky', wrap(Lucky,
+        () => {
+            return (Math.random() > 0.5)
+        },
+        () => {
+            return true
+        }
+    ))
 
     // Regular expressions
     routes.set(/^\/regex\/(.*)?/i, Regex)

--- a/example/src/routes.js
+++ b/example/src/routes.js
@@ -35,10 +35,21 @@ if (!urlParams.has('routemap')) {
 
         // This route has a pre-condition function that lets people in only 50% of times (and a second pre-condition that is always true)
         '/lucky': wrap(Lucky,
-            () => {
+            (loc) => {
+                // If there's a query-string parameter, override the random choice (tests need to be deterministic)
+                if (loc) {
+                    if (loc.querystring == 'pass=1') {
+                        return true
+                    }
+                    else if (loc.querystring == 'pass=0') {
+                        return false
+                    }
+                }
+                // Random
                 return (Math.random() > 0.5)
             },
-            () => {
+            (loc) => {
+                // Always returns true
                 return true
             }
         ),

--- a/example/src/routes/Lucky.svelte
+++ b/example/src/routes/Lucky.svelte
@@ -1,0 +1,3 @@
+<h1>You're in!</h1>
+
+<p>This route has a pre-condition that stops it from loading 50% of the time. So, you were lucky you could load this route! Now, try refreshing the page.</p>

--- a/example/src/routes/Lucky.svelte
+++ b/example/src/routes/Lucky.svelte
@@ -1,3 +1,3 @@
-<h1>You're in!</h1>
+<h1 id="lucky">You're in!</h1>
 
 <p>This route has a pre-condition that stops it from loading 50% of the time. So, you were lucky you could load this route! Now, try refreshing the page.</p>

--- a/package.json
+++ b/package.json
@@ -32,17 +32,16 @@
     "regexparam": "^1.3.0"
   },
   "devDependencies": {
-    "chromedriver": "^76.0.0",
-    "eslint": "^6.1.0",
+    "eslint": "^6.6.0",
     "eslint-plugin-html": "^6.0.0",
     "eslint-plugin-svelte3": "^2.7.3",
-    "nightwatch": "^1.1.13",
-    "rollup": "^1.17.0",
-    "rollup-plugin-commonjs": "^10.0.1",
+    "nightwatch": "^1.2.4",
+    "rollup": "^1.26.0",
+    "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-svelte": "^5.1.0",
-    "serve": "^11.1.0",
-    "svelte": "^3.6.10"
+    "serve": "^11.2.0",
+    "svelte": "^3.12.1"
   },
   "peerDependencies": {
     "svelte": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "regexparam": "^1.3.0"
   },
   "devDependencies": {
+    "chromedriver": "^77.0.0",
     "eslint": "^6.6.0",
     "eslint-plugin-html": "^6.0.0",
     "eslint-plugin-svelte3": "^2.7.3",

--- a/test/01-routing.test.js
+++ b/test/01-routing.test.js
@@ -264,5 +264,18 @@ describe('<Router> component', function() {
                 browser.end()
             })
     })
+
+    it('routeLoaded event', (browser) => {
+        browser
+            .url('http://localhost:5000')
+            .waitForElementPresent('#logbox')
+            .expect.element('#logbox').text.to.equal('routeLoaded - Home')
+        
+        browser.url('http://localhost:5000/#/hello/svelte')
+            .waitForElementPresent('#logbox')
+            .expect.element('#logbox').text.to.equal('routeLoaded - Name')
+        
+        browser.end()
+    })
 })
 

--- a/test/01-routing.test.js
+++ b/test/01-routing.test.js
@@ -252,7 +252,7 @@ describe('<Router> component', function() {
             .assert.containsText('h2.routetitle', 'Hi there!')
             .expect.element('#currentpath').text.to.equal('/hello/svelte')
         browser.expect.element('#currentqs').text.to.equal('search=query&sort=0')
-        
+
         // Refresh the page
         browser
             .refresh(() => {
@@ -270,11 +270,44 @@ describe('<Router> component', function() {
             .url('http://localhost:5000')
             .waitForElementPresent('#logbox')
             .expect.element('#logbox').text.to.equal('routeLoaded - Home')
-        
+
         browser.url('http://localhost:5000/#/hello/svelte')
             .waitForElementPresent('#logbox')
-            .expect.element('#logbox').text.to.equal('routeLoaded - Name')
-        
+            .expect.element('#logbox').text.to.equal('routeLoaded - Home\nrouteLoaded - Name')
+
+        browser.end()
+    })
+
+    it('route conditions', (browser) => {
+        // Condition always passes
+        browser
+            .url('http://localhost:5000/#/lucky?pass=1')
+            .waitForElementVisible('#lucky')
+            .expect.element('#currentpath').text.to.equal('/lucky')
+        browser.expect.element('#lucky').text.to.equal('You\'re in!')
+
+        // Condition always fails
+        browser.url('http://localhost:5000/#/lucky?pass=0')
+            .waitForElementVisible('h2.routetitle')
+            .assert.containsText('h2.routetitle', 'Wild')
+            .expect.element('#currentpath').text.to.equal('/wild/conditions-failed')
+        browser.expect.element('#currentqs').text.to.equal('')
+
+        browser.end()
+    })
+
+    it('conditionsFailed event', (browser) => {
+        // Condition always passes
+        browser
+            .url('http://localhost:5000/#/lucky?pass=1')
+            .waitForElementPresent('#logbox')
+            .expect.element('#logbox').text.to.equal('routeLoaded - Lucky')
+
+        // Condition always fails
+        browser.url('http://localhost:5000/#/lucky?pass=0')
+            .waitForElementPresent('#logbox')
+            .expect.element('#logbox').text.to.equal('routeLoaded - Lucky\nconditionsFailed - Lucky\nrouteLoaded - Wild')
+
         browser.end()
     })
 })

--- a/test/01-routing.test.js
+++ b/test/01-routing.test.js
@@ -269,11 +269,11 @@ describe('<Router> component', function() {
         browser
             .url('http://localhost:5000')
             .waitForElementPresent('#logbox')
-            .expect.element('#logbox').text.to.equal('routeLoaded - Home')
+            .expect.element('#logbox').text.to.equal('routeLoaded - {"component":"Home","location":"/","querystring":""}')
 
         browser.url('http://localhost:5000/#/hello/svelte')
             .waitForElementPresent('#logbox')
-            .expect.element('#logbox').text.to.equal('routeLoaded - Home\nrouteLoaded - Name')
+            .expect.element('#logbox').text.to.equal('routeLoaded - {"component":"Home","location":"/","querystring":""}\nrouteLoaded - {"component":"Name","location":"/hello/svelte","querystring":""}')
 
         browser.end()
     })
@@ -301,12 +301,12 @@ describe('<Router> component', function() {
         browser
             .url('http://localhost:5000/#/lucky?pass=1')
             .waitForElementPresent('#logbox')
-            .expect.element('#logbox').text.to.equal('routeLoaded - Lucky')
+            .expect.element('#logbox').text.to.equal('routeLoaded - {"component":"Lucky","location":"/lucky","querystring":"pass=1"}')
 
         // Condition always fails
         browser.url('http://localhost:5000/#/lucky?pass=0')
             .waitForElementPresent('#logbox')
-            .expect.element('#logbox').text.to.equal('routeLoaded - Lucky\nconditionsFailed - Lucky\nrouteLoaded - Wild')
+            .expect.element('#logbox').text.to.equal('routeLoaded - {"component":"Lucky","location":"/lucky","querystring":"pass=1"}\nconditionsFailed - {"component":"Lucky","location":"/lucky","querystring":"pass=0"}\nrouteLoaded - {"component":"Wild","location":"/wild/conditions-failed","querystring":""}')
 
         browser.end()
     })


### PR DESCRIPTION
This could fix #23 by allowing the definition of any number of "pre-conditions" before a route can be displayed.

Pre-conditions can be defined in the route object by using the `wrap` function (`import {wrap} from 'svelte-spa-router'). For example, in the route object:

````js
// This route has a pre-condition function that lets people in only 50% of times (and a second pre-condition that is always true)
'/lucky': wrap(Lucky,
    () => {
        return (Math.random() > 0.5)
    },
    () => {
        return true
    }
),
````

Before showing the `Lucky` component, the router executes all pre-conditions, and if one returns false then it does not show any route.

This also adds an event to the `Router` component: `conditionsfail`, which is triggered if one of the pre-conditions has failed and so no route is shown.

This PR for now is meant to be for discussing the design of the API. I have not written tests yet, nor properly documented it.

CC: @TorstenDittmann 