### PR TITLE
Keep pathname in url for example "index.html" will be kept not replaced

### DIFF
--- a/Router.svelte
+++ b/Router.svelte
@@ -6,7 +6,7 @@ import {readable, derived} from 'svelte/store'
 
 /**
  * Wraps a route to add route pre-conditions.
- * 
+ *
  * @param {SvelteComponent} route - Svelte component for the route
  * @param {Object} [userData] - Optional object that will be passed to each `conditionsFailed` event
  * @param {...Function} conditions - Route pre-conditions to add, which will be executed in order
@@ -176,7 +176,7 @@ export function link(node) {
     }
 
     // Add # to every href attribute
-    node.setAttribute('href', '#' + href)
+    node.setAttribute('href', window.location.pathname + '#' + href);
 }
 </script>
 
@@ -224,7 +224,7 @@ class RouteItem {
         }
 
         // Path must be a regular or expression, or a string starting with '/' or '*'
-        if (!path || 
+        if (!path ||
             (typeof path == 'string' && (path.length < 1 || (path.charAt(0) != '/' && path.charAt(0) != '*'))) ||
             (typeof path == 'object' && !(path instanceof RegExp))
         ) {
@@ -296,7 +296,7 @@ class RouteItem {
 
     /**
      * Executes all conditions (if any) to control whether the route can be shown. Conditions are executed in the order they are defined, and if a condition fails, the following ones aren't executed.
-     * 
+     *
      * @param {RouteDetail} detail - Route detail
      * @returns {bool} Returns true if all the conditions succeeded
      */

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build-example": "(cd example && npx rollup -c)",
     "start-example": "npx serve -n -l 5000 example/dist",
+    "start:dev": "sirv example/dist --dev",
     "eslint": "npx eslint -c .eslintrc.js --ext .js,.svelte,.html .",
     "lint": "npm run eslint",
     "nightwatch": "npx nightwatch",
@@ -42,6 +43,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-svelte": "^5.1.1",
     "serve": "^11.2.0",
+    "sirv-cli": "^0.4.5",
     "svelte": "^3.14.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
# The problem
"index.html", is being replaced with "/", which means, if you are not handling "/", it doesn't work properly until the spa has programmatically changed the url (for instance via clicking "replace current page").

I reached this "bug" via using this great tool as my router in a chrome extension.

# Info

This PR, if wanted, will need to be updated to remove the new package dependency, or you are welcome to say move to sirv.

# What is in here

1) the first commit is the fix.
2) the other commit, is to add another server that doesnt replace "index.html" with "/", to make it clearer what the problem is.