### PR TITLE
push, pop, replace return a promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ These methods can be used inside Svelte markup too, for example:
 <button on:click={() => push('/page')}>Go somewhere</button>
 ````
 
-_Note: The `push`, `pop` and `replace` methods perform navigation actions only in the next iteration ("tick") of the JavaScript event loop. This makes it safe to use them also inside `onMount` callbacks within Svelte components._
+The `push`, `pop` and `replace` methods perform navigation actions only in the next iteration ("tick") of the JavaScript event loop. This makes it safe to use them also inside `onMount` callbacks within Svelte components. The functions return a Promise that resolves with no value once the navigation has been triggered (in the next tick of the event loop); however, please note that this will likely be before the new page has rendered.
 
 ### Parameters from routes
 

--- a/Router.svelte
+++ b/Router.svelte
@@ -110,6 +110,7 @@ export const querystring = derived(
  * Navigates to a new page programmatically.
  *
  * @param {string} location - Path to navigate to (must start with `/` or '#/')
+ * @return {Promise} Promise that resolves after the page navigation has completed
  */
 export function push(location) {
     if (!location || location.length < 1 || (location.charAt(0) != '/' && location.indexOf('#/') !== 0)) {
@@ -117,25 +118,28 @@ export function push(location) {
     }
 
     // Execute this code when the current call stack is complete
-    setTimeout(() => {
+    return nextTickPromise(() => {
         window.location.hash = (location.charAt(0) == '#' ? '' : '#') + location
-    }, 0)
+    })
 }
 
 /**
  * Navigates back in history (equivalent to pressing the browser's back button).
+ * 
+ * @return {Promise} Promise that resolves after the page navigation has completed
  */
 export function pop() {
     // Execute this code when the current call stack is complete
-    setTimeout(() => {
+    return nextTickPromise(() => {
         window.history.back()
-    }, 0)
+    })
 }
 
 /**
  * Replaces the current page but without modifying the history stack.
  *
  * @param {string} location - Path to navigate to (must start with `/` or '#/')
+ * @return {Promise} Promise that resolves after the page navigation has completed
  */
 export function replace(location) {
     if (!location || location.length < 1 || (location.charAt(0) != '/' && location.indexOf('#/') !== 0)) {
@@ -143,7 +147,7 @@ export function replace(location) {
     }
 
     // Execute this code when the current call stack is complete
-    setTimeout(() => {
+    return nextTickPromise(() => {
         const dest = (location.charAt(0) == '#' ? '' : '#') + location
         try {
             window.history.replaceState(undefined, undefined, dest)
@@ -155,7 +159,7 @@ export function replace(location) {
 
         // The method above doesn't trigger the hashchange event, so let's do that manually
         window.dispatchEvent(new Event('hashchange'))
-    }, 0)
+    })
 }
 
 /**
@@ -183,6 +187,20 @@ export function link(node) {
 
     // Add # to every href attribute
     node.setAttribute('href', '#' + href)
+}
+
+/**
+ * Performs a callback in the next tick and returns a Promise that resolves once that's done
+ * 
+ * @param {Function} cb - Callback to invoke
+ * @returns {Promise} Promise that resolves after the callback has been invoked, with the return value of the callback (if any)
+ */
+export function nextTickPromise(cb) {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            resolve(cb())
+        }, 0)
+    })
 }
 </script>
 


### PR DESCRIPTION
The methods `push`, `pop`, and `replace` now return a promise that resolves on the next tick, after the navigation has been triggered (but note there's new guarantee the new page has rendered yet!).

This would let users `await` on calls to methods like `push()`.

Opening this as a proposal as it's simple enough that I could just implement it straight away, but I'm not sure if this will be of much use to the developers using this library.

Idea came after reading #93, thinking it might help with the scenario of the duplicated routes.

@hmmhmmhm would love your thoughts too if you can! 😄 