### PR TITLE
Allow use:link elements to be updated if the href changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ import {link} from 'svelte-spa-router'
 <a href="/book/321" use:link>The Little Prince</a>
 ````
 
+If you have a link that is set to a varible, you can also use the `use:link={variable}` action:
+
+````svelte
+<script>
+import {link} from 'svelte-spa-router'
+let myLink = "/book/456"
+</script>
+<a use:link={myLink}>The Biggest Princess</a>
+````
+
 You can navigate between pages programmatically too:
 
 ````js

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ import {link} from 'svelte-spa-router'
 <a href="/book/321" use:link>The Little Prince</a>
 ````
 
-If you have a link that is set to a varible, you can also use the `use:link={variable}` action:
+You can also use the `use:link={variable}` action to have your link set to a variable and updated reactively (this will always take precedence over `href` attributes, if present):
 
 ````svelte
 <script>

--- a/Router.svelte
+++ b/Router.svelte
@@ -184,7 +184,7 @@ export function link(node, hrefVar) {
 
     return {
         update(updated) {
-            updateLink(updated)
+            updateLink(node, updated)
         }
     }
 }

--- a/Router.svelte
+++ b/Router.svelte
@@ -173,25 +173,37 @@ export function replace(location) {
  *
  * @param {HTMLElement} node - The target node (automatically set by Svelte). Must be an anchor tag (`<a>`) with a href attribute starting in `/`
  */
-export function link(node) {
+export function link(node, hrefVar) {
     // Only apply to <a> tags
     if (!node || !node.tagName || node.tagName.toLowerCase() != 'a') {
         throw Error('Action "link" can only be used with <a> tags')
     }
 
     // Destination must start with '/'
-    const href = node.getAttribute('href')
+    const href = hrefVar || node.getAttribute('href')
     if (!href || href.length < 1 || href.charAt(0) != '/') {
         throw Error('Invalid value for "href" attribute')
     }
 
     // Add # to every href attribute
     node.setAttribute('href', '#' + href)
+
+    return {
+        update(updated) {
+            const href = updated
+            if (!href || href.length < 1 || href.charAt(0) != '/') {
+                throw Error('Invalid value for "href" attribute')
+            }
+
+            // Add # to every href attribute
+            node.setAttribute('href', '#' + href)
+        },
+    }
 }
 
 /**
  * Performs a callback in the next tick and returns a Promise that resolves once that's done
- * 
+ *
  * @param {Function} cb - Callback to invoke
  * @returns {Promise} Promise that resolves after the callback has been invoked, with the return value of the callback (if any)
  */

--- a/Router.svelte
+++ b/Router.svelte
@@ -172,6 +172,7 @@ export function replace(location) {
  * ````
  *
  * @param {HTMLElement} node - The target node (automatically set by Svelte). Must be an anchor tag (`<a>`) with a href attribute starting in `/`
+ * @param {string} hrefVar - A string to use in place of the link's href attribute. Using this allows for updating link's targets reactively.
  */
 export function link(node, hrefVar) {
     // Only apply to <a> tags

--- a/Router.svelte
+++ b/Router.svelte
@@ -180,26 +180,24 @@ export function link(node, hrefVar) {
         throw Error('Action "link" can only be used with <a> tags')
     }
 
+    updateLink(node, hrefVar || node.getAttribute('href'))
+
+    return {
+        update(updated) {
+            updateLink(updated)
+        }
+    }
+}
+
+// Internal function used by the link function
+function updateLink(node, href) {
     // Destination must start with '/'
-    const href = hrefVar || node.getAttribute('href')
     if (!href || href.length < 1 || href.charAt(0) != '/') {
         throw Error('Invalid value for "href" attribute')
     }
 
-    // Add # to every href attribute
+    // Add # to the href attribute
     node.setAttribute('href', '#' + href)
-
-    return {
-        update(updated) {
-            const href = updated
-            if (!href || href.length < 1 || href.charAt(0) != '/') {
-                throw Error('Invalid value for "href" attribute')
-            }
-
-            // Add # to every href attribute
-            node.setAttribute('href', '#' + href)
-        },
-    }
 }
 
 /**

--- a/example/src/routes.js
+++ b/example/src/routes.js
@@ -3,6 +3,7 @@
 import {wrap} from '../../Router.svelte'
 
 // Components
+import Catalog from './routes/Catalog.svelte'
 import Home from './routes/Home.svelte'
 import Name from './routes/Name.svelte'
 import Wild from './routes/Wild.svelte'
@@ -23,13 +24,16 @@ if (!urlParams.has('routemap')) {
     routes = {
         // Exact path
         '/': Home,
-    
+
         // Allow children to also signal link activation
         '/brand': Home,
-        
+
         // Using named parameters, with last being optional
         '/hello/:first/:last?': Name,
-    
+
+        // Using named parameters, with last being optional
+        '/catalog/:id?': Catalog,
+
         // Wildcard parameter
         '/wild': Wild,
         // Special route that has custom data that will be passed to the `routeLoaded` event
@@ -65,7 +69,7 @@ if (!urlParams.has('routemap')) {
         // Note that we must match both '/nested' and '/nested/*' for the nested router to work (or look below at doing this with a Map and a regular expression)
         '/nested': Nested,
         '/nested/*': Nested,
-    
+
         // Catch-all, must be last
         '*': NotFound,
     }

--- a/example/src/routes/Catalog.svelte
+++ b/example/src/routes/Catalog.svelte
@@ -1,0 +1,13 @@
+<h1 id="catalog">Item {id}</h1>
+
+<a id="previous" href use:link={`/catalog/${id - 1}`}>Previous</a>
+<a id="next" href use:link={`/catalog/${id + 1}`}>Next</a>
+
+<script>
+  import {link} from '../../../Router.svelte'
+  export let params
+  let id
+  $: if (params) {
+      id = parseInt(params.id, 10)
+  }
+</script>

--- a/test/01-routing.test.js
+++ b/test/01-routing.test.js
@@ -325,5 +325,22 @@ describe('<Router> component', function() {
 
         browser.end()
     })
+
+    it('use:link vars', (browser) => {
+        // Condition always passes
+        browser
+            .url('http://localhost:5000/#/catalog/3')
+            .waitForElementPresent('#logbox')
+            .expect.element('#logbox').text.to.equal('routeLoaded - {"name":"Catalog","location":"/catalog/3","querystring":""}')
+        browser.expect.element('#previous').attribute('href').to.endsWith('#/catalog/2')
+        browser.expect.element('#next').attribute('href').to.endsWith('#/catalog/4')
+        browser.click('#next', () => {
+            browser.waitForElementVisible('#logbox')
+                .expect.element('#logbox').text.to.equal('routeLoaded - {"name":"Catalog","location":"/catalog/3","querystring":""}\nrouteLoaded - {"name":"Catalog","location":"/catalog/4","querystring":""}')
+            browser.expect.element('#previous').attribute('href').to.endsWith('#/catalog/3')
+            browser.expect.element('#next').attribute('href').to.endsWith('#/catalog/5')
+        })
+        browser.end()
+    })
 })
 


### PR DESCRIPTION
I was building pages to allow users to navigate thru a catalog with next and previous links. I was generating the next and previous links when the page detected a change in the params for the item id to display.  I found that the my `<a href={nextLink} use:link>next</a>` were not updating with the `#` in front href in navigating to subsiquent pages.  