### PR TITLE
[WIP]Prefix params

### DIFF
--- a/Router.svelte
+++ b/Router.svelte
@@ -299,7 +299,7 @@ class RouteItem {
      */
     match(path) {
         // If there's a prefix, remove it before we run the matching
-        if (prefix && path.startsWith(prefix)) {
+        if (prefix && path.startsWith(prefix) && path instanceof RegExp) {
             path = path.substr(prefix.length) || '/'
         }
 

--- a/Router.svelte
+++ b/Router.svelte
@@ -360,7 +360,8 @@ if (routes instanceof Map) {
 else {
     // We have an object, so iterate on its own properties
     Object.keys(routes).forEach((path) => {
-        routesList.push(new RouteItem(path, routes[path]))
+        const prefixedPath = prefix + path
+        routesList.push(new RouteItem(prefixedPath, routes[path]))
     })
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "regexparam": "1.3.0"
   },
   "devDependencies": {
-    "chromedriver": "^80.0.1",
+    "chromedriver": "^84.0.1",
     "eslint": "^7.1.0",
     "eslint-plugin-html": "^6.0.2",
     "eslint-plugin-svelte3": "^2.7.3",


### PR DESCRIPTION
Hey there, currently building an application with some friends and this router.
We got a lot of routes so it would be nice to use parms in prefixes.

I decided to commit a draft in case this is not something the router should do.

But I think the changes are very few. So if you like the direction I am willing to put some more work in this.

Implements support for this:
```
const prefix = '/characters/:characterId';
const routes = {
  'armors/:armorId': Armors
}

<Router {routes} {prefix}>
```
which matches on routes like `/characters/some_id/armors/some_id` and lets you fetch both params