### PR TITLE
Fix route matching

### DIFF
--- a/Router.svelte
+++ b/Router.svelte
@@ -300,15 +300,24 @@ class RouteItem {
      * @returns {null|Object.<string, string>} List of paramters from the URL if there's a match, or `null` otherwise.
      */
     match(path) {
-        // If there's a prefix, remove it before we run the matching
+        // If there's a prefix, check if it matches the start of the path.
+        // If not, bail early, else remove it before we run the matching.
         if (prefix) {
-            if (typeof prefix == 'string' && path.startsWith(prefix)) {
-                path = path.substr(prefix.length) || '/'
+            if (typeof prefix == 'string') {
+                if (path.startsWith(prefix)) {
+                    path = path.substr(prefix.length) || '/'
+                }
+                else {
+                    return null
+                }
             }
             else if (prefix instanceof RegExp) {
                 const match = path.match(prefix)
                 if (match && match[0]) {
                     path = path.substr(match[0].length) || '/'
+                }
+                else {
+                    return null
                 }
             }
         }


### PR DESCRIPTION
Take prefix into account and bail early if path does not start with prefix.
Fixes #169

This contains no tests because I was not sure how to test it given the current test setup. I think some kind of unit test would be nice. Feel free to take over if you want.