### PR TITLE
A mechanism to lock navigation in all routers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,4 +178,8 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# IntelliJ IDEA
+*.iml
+.idea
+
 # End of https://www.gitignore.io/api/node,macos,linux,windows,visualstudiocode

--- a/Router.svelte
+++ b/Router.svelte
@@ -1,5 +1,5 @@
 <script context="module">
-import {readable, derived} from 'svelte/store'
+import {readable, derived, writable} from 'svelte/store'
 import {tick} from 'svelte'
 import {wrap as _wrap} from './wrap'
 
@@ -84,6 +84,18 @@ export const querystring = derived(
     loc,
     ($loc) => $loc.querystring
 )
+
+/**
+ * A route lock is an application wide locking of route navigation.
+ *
+ * When route lock is enabled {@code lock.set(true)}
+ * the hashchange events do not have any effect in routers.
+ *
+ * The route locking enables applications to handle hashchange events manually.
+ * This is useful e.g. for implementing a dirty form confirmation dialog
+ * when navigating to other page.
+ */
+export const lock = writable(false)
 
 /**
  * Navigates to a new page programmatically.
@@ -447,6 +459,10 @@ let componentObj = null
 // Listen to changes in the $loc store and update the page
 // Do not use the $: syntax because it gets triggered by too many things
 loc.subscribe(async (newLoc) => {
+    if ($lock) {
+        return
+    }
+
     lastLoc = newLoc
 
     // Find a route matching the location


### PR DESCRIPTION
When the lock is enabled (lock.set(true)) the hashchange events do not have any effect in routers. The state of all components remains unaffected.

I could not figure out any other way to implement a navigation confirmation dialog for an unsaved dirty form. 

Here is an example of a navigation confirmation dialog, which is using this feature:

https://github.com/solita/etp-front/blob/450d40a80569a163acca8f0fca8e202242608e1d/src/components/Confirm/dirty.svelte

If there is other way of doing this then this feature is redundant, but I just could not figure out how to do it. 

