### PR TITLE
fix(rollup): fix option to avoid warning

### DIFF
--- a/examples/basic-routing/rollup.config.js
+++ b/examples/basic-routing/rollup.config.js
@@ -15,7 +15,9 @@ export default {
     plugins: [
         svelte({
             // enable run-time checks when not in production
-            dev: true,
+            compilerOptions: {
+                dev: true,
+            },
         }),
         // we'll extract any component CSS out into
         // a separate file better for performance

--- a/examples/dynamic-imports/rollup.config.js
+++ b/examples/dynamic-imports/rollup.config.js
@@ -15,7 +15,9 @@ export default {
     plugins: [
         svelte({
             // enable run-time checks when not in production
-            dev: true,
+            compilerOptions: {
+                dev: true,
+            },
         }),
         // we'll extract any component CSS out into
         // a separate file better for performance


### PR DESCRIPTION
When run examples I got the following warning:

`[rollup-plugin-svelte] Unknown "dev" option. Please use "compilerOptions" for any Svelte compiler configuration.`

After checking the interface file, I found that the rollup config need to be updated which the dev option should be inside `CompileOptions` object.

For more information, see:
https://github.com/sveltejs/rollup-plugin-svelte/blob/master/index.d.ts
https://github.com/sveltejs/svelte/blob/master/src/compiler/interfaces.ts