### PR TITLE
feat: Add support for `routeLoaded` component function (feature request)

### DIFF
--- a/Router.svelte
+++ b/Router.svelte
@@ -548,6 +548,16 @@ const unsubscribeLoc = loc.subscribe(async (newLoc) => {
 
             // Invoke the Promise
             const loaded = await obj()
+            // If component owns a routeLoaded function, proceed accordingly based on its return value
+            if (loaded.routeLoaded) {
+                const isAborted = !await loaded.routeLoaded(Object.assign({}, detail))
+                if (isAborted) {
+                    component = null
+                    componentObj = null
+                    componentParams = null
+                    return;
+                }
+            }
 
             // Now that we're here, after the promise resolved, check if we still want this component, as the user might have navigated to another page in the meanwhile
             if (newLoc != lastLoc) {

--- a/Router.svelte
+++ b/Router.svelte
@@ -550,13 +550,7 @@ const unsubscribeLoc = loc.subscribe(async (newLoc) => {
             const loaded = await obj()
             // If component owns a routeLoaded function, proceed accordingly based on its return value
             if (loaded.routeLoaded) {
-                const isAborted = !await loaded.routeLoaded(Object.assign({}, detail))
-                if (isAborted) {
-                    component = null
-                    componentObj = null
-                    componentParams = null
-                    return;
-                }
+                await loaded.routeLoaded(Object.assign({}, detail))
             }
 
             // Now that we're here, after the promise resolved, check if we still want this component, as the user might have navigated to another page in the meanwhile


### PR DESCRIPTION
I have this proposal, though it might be rather confusing. There are cases one needs to fetch data before navigation is completed.
Preconditions are one method provided that all callbacks are registered in `routes` file and always return `true`.

I was thinking of a concept that one can fetch data inside component itself, before component mounting.
My thought was a `routeLoaded` callback per component. Its name may need to be different, in order to avoid confusion with `Router`'s events.

This callback will have `async/await` support. Additionally, loading component will be displayed until callback is resolved (e.g. fetching data), which makes loading configuration even more useful than before.

Also, I avoided using it to abort navigation since preconditions are made for this.

I have created a PR to show required changes.

So here is how developers would use it:
```
<script context="module">
  var data = null;
  export async function routeLoaded() {
    data = [1, 2, 3, 4, 5];
    await myAsyncFunction();
  }
</script>
<script>
  import myAwesomeModule from "myAwesomeModule";

  // And array of data is populated here
  console.log(data);
</script>
```

It's probably a confusing feature, but I was thinking of putting this suggestion on the table.
In general, I feel it would be convenient to use `async/await` and halt navigation within component file to keep code separated, without meddling with registering everything inside route `wrap`.