### PR TITLE
feat: Using svelte slot as a means to override current component (feature-request)

### DIFF
--- a/Router.svelte
+++ b/Router.svelte
@@ -241,20 +241,22 @@ function scrollstateHistoryHandler(href) {
 }
 </script>
 
-{#if componentParams}
-    <svelte:component
-    this="{component}"
-    params="{componentParams}"
-    on:routeEvent
-    {...props}
-    />
-{:else}
-    <svelte:component
-    this="{component}"
-    on:routeEvent
-    {...props}
-    />
-{/if}
+<slot>
+    {#if componentParams}
+        <svelte:component
+        this="{component}"
+        params="{componentParams}"
+        on:routeEvent
+        {...props}
+        />
+    {:else}
+        <svelte:component
+        this="{component}"
+        on:routeEvent
+        {...props}
+        />
+    {/if}
+</slot>
 
 <script>
 import {onDestroy, createEventDispatcher, afterUpdate} from 'svelte'


### PR DESCRIPTION
There might be cases one wants to temporarily hide current route component.
`loadingComponent` must be registered for each route and is used only for a certain case so it cannot be used at all times.
Slot fallback is a really nice mechanism to use for this concept.

Example:
**App.svelte**
```
<!-- If router is empty, it will display fallback which is current route component -->
<Router {routes}>
    <div>I could be an ajax loader or anything to hide current page</div>
</Router>
```