### PR TITLE
fix: Prevent duplicate location update on `Router` mount/unmount

### DIFF
--- a/Router.svelte
+++ b/Router.svelte
@@ -491,6 +491,7 @@ let componentObj = null
 // Listen to changes in the $loc store and update the page
 // Do not use the $: syntax because it gets triggered by too many things
 const unsubscribeLoc = loc.subscribe(async (newLoc) => {
+    // Avoid rendering if location is exactly the same as before (happens on Router unmount/mount)
     if (lastLoc === newLoc) {
         return
     }

--- a/Router.svelte
+++ b/Router.svelte
@@ -239,6 +239,9 @@ function scrollstateHistoryHandler(href) {
     // This will force an update as desired, but this time our scroll state will be attached
     window.location.hash = href
 }
+
+// Always have the latest value of loc
+let lastLoc = null
 </script>
 
 {#if componentParams}
@@ -481,9 +484,6 @@ if (restoreScrollState) {
     })
 }
 
-// Always have the latest value of loc
-let lastLoc = null
-
 // Current object of the component loaded
 let componentObj = null
 
@@ -491,6 +491,9 @@ let componentObj = null
 // Listen to changes in the $loc store and update the page
 // Do not use the $: syntax because it gets triggered by too many things
 const unsubscribeLoc = loc.subscribe(async (newLoc) => {
+    if (lastLoc === newLoc) {
+        return
+    }
     lastLoc = newLoc
 
     // Find a route matching the location


### PR DESCRIPTION
This change keeps last route location stored even after mount/unmount.
Additionally, it checks whether new location is identical to last location.
Object comparison works because store retrieves exactly the same location object as before.

This issue occured to me when I was unmounting `Router` in order to change view layout.
In fact, `loc` subscription was triggered before unmount and new subscription was also triggered on remount.

This check solves problems for that concept provided that layout is changed before navigation (e.g. from /login to /home and vice-versa).