### PR TITLE
Remove 'undefined' from history.replaceState() optional url parameter.

### DIFF
--- a/Router.svelte
+++ b/Router.svelte
@@ -107,7 +107,7 @@ export async function push(location) {
     await tick()
 
     // Note: this will include scroll state in history even when restoreScrollState is false
-    history.replaceState({...history.state, __svelte_spa_router_scrollX: window.scrollX, __svelte_spa_router_scrollY: window.scrollY}, undefined, undefined)      
+    history.replaceState({...history.state, __svelte_spa_router_scrollX: window.scrollX, __svelte_spa_router_scrollY: window.scrollY}, undefined)      
     window.location.hash = (location.charAt(0) == '#' ? '' : '#') + location
 }
 
@@ -235,7 +235,7 @@ function linkOpts(val) {
  */
 function scrollstateHistoryHandler(href) {
     // Setting the url (3rd arg) to href will break clicking for reasons, so don't try to do that
-    history.replaceState({...history.state, __svelte_spa_router_scrollX: window.scrollX, __svelte_spa_router_scrollY: window.scrollY}, undefined, undefined)
+    history.replaceState({...history.state, __svelte_spa_router_scrollX: window.scrollX, __svelte_spa_router_scrollY: window.scrollY}, undefined)
     // This will force an update as desired, but this time our scroll state will be attached
     window.location.hash = href
 }


### PR DESCRIPTION
I am aware that this project does not support Internet Explorer nor has any intention of doing so. BUT! Some of us do have to support IE11 and all of its quirkness.

This PR addresses an issue that only seem to happen on IE11, where the `undefined` value passed into the `url` param on `history.replaceState` is ready by IE as a string and ends up being used in the constructed url causing something like: `https://www.domain.com/undefined#/some-route`

From my reading of the [`history.replaceState` documentation](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState), the `url` parameter is optional so, it should be safe to omit it where necessary rather than have `undefined` passed in.

There would be no actual change to any implementation already in place and would prevent the issue I encoutered when implementing svelte-spa-router in Internet Explorer 11.