### PR TITLE
feat: add dynamic props

### DIFF
--- a/Router.d.ts
+++ b/Router.d.ts
@@ -177,6 +177,9 @@ interface RouterEvent<T> {
 /** Event type for conditionsFailed */
 export type ConditionsFailedEvent = RouterEvent<RouteDetail>
 
+/** Event type for propsFailed */
+export type PropsFailedEvent = RouterEvent<RouteDetail>
+
 /** Event type for routeLoading */
 export type RouteLoadingEvent = RouterEvent<RouteDetail>
 
@@ -218,6 +221,7 @@ export default class Router extends SvelteComponent {
 
     $on(event: 'routeEvent', callback: (event: CustomEvent) => void): () => void
     $on(event: 'conditionsFailed', callback: (event: ConditionsFailedEvent) => void): () => void
+    $on(event: 'propsFailed', callback: (event: PropsFailedEvent) => void): () => void
     $on(event: 'routeLoading', callback: (event: RouteLoadingEvent) => void): () => void
     $on(event: 'routeLoaded', callback: (event: RouteLoadedEvent) => void): () => void
 }

--- a/test/app/src/routes.js
+++ b/test/app/src/routes.js
@@ -100,7 +100,10 @@ if (!urlParams.has('routemap')) {
         // This route has a static prop that is passed to it
         '/foo': wrap({
             component: Foo,
-            props: {staticProp: 'this is static'}
+            props: {
+                staticProp: 'this is static',
+                dynamicProp: async () => Promise.resolve(`this is dynamic - ${new Date}`),
+            }
         }),
 
         // This component contains a nested router

--- a/test/app/src/routes/Foo.svelte
+++ b/test/app/src/routes/Foo.svelte
@@ -4,7 +4,15 @@
   <p>No static props here!</p>
 {/if}
 
+{dynamicProp}
+{#if dynamicProp}
+  <p>We have a static prop: <b id="dynamicprop">{dynamicProp}</b></p>
+{:else}
+  <p>No static props here!</p>
+{/if}
+
 <script>
 // Static props if they're set
 export let staticProp = null
+export let dynamicProp = null
 </script>

--- a/test/cases/01-routing.test.js
+++ b/test/cases/01-routing.test.js
@@ -385,4 +385,13 @@ describe('<Router> component', function() {
 
         browser.end()
     })
+    
+    it('dynamic props', (browser) => {
+        browser
+            .url(browser.launchUrl + '/#/foo')
+            .waitForElementVisible('#dynamicprop')
+            .expect.element('#dynamicprop').text.to.startWith('this is dynamic')
+
+        browser.end()
+    })
 })


### PR DESCRIPTION
It lets you pass dynamic props to the loaded component. It adheres to the routing cycle and renders components only after the props are resolved. It raises propsFailed event for each prop when the prop fails to resolve.

Follows how you would pass dynamic props to your component. 

```javascript
'/foo': wrap({
    component: Foo,
    props: {
        staticProp: 'this is static',
        dynamicProp: async () => Promise.resolve(`this is dynamic - ${new Date}`),
        anotherProps: () => `Just works!`
    }
 }),
```