### PR TITLE
don't use $ as a prefix in derived

### DIFF
--- a/Router.svelte
+++ b/Router.svelte
@@ -74,7 +74,7 @@ export const loc = readable(
  */
 export const location = derived(
     loc,
-    ($loc) => $loc.location
+    (_loc) => _loc.location
 )
 
 /**
@@ -82,7 +82,7 @@ export const location = derived(
  */
 export const querystring = derived(
     loc,
-    ($loc) => $loc.querystring
+    (_loc) => _loc.querystring
 )
 
 /**


### PR DESCRIPTION
The svelte 5 compiler was complaining about the use of the `$` in the variable names:
```
[vite-plugin-svelte] /home/damjan/projects/irclogs/svelte/node_modules/.pnpm/svelte-spa-router@3.3.0/node_modules/svelte-spa-router/Router.svelte:77:5 The $ prefix is reserved, and cannot be used for variables and imports
file: /home/damjan/projects/irclogs/svelte/node_modules/.pnpm/svelte-spa-router@3.3.0/node_modules/svelte-spa-router/Router.svelte:77:5
error during build:
CompileError: The $ prefix is reserved, and cannot be used for variables and imports
```

I choose `_loc` for now, just to see it working. Suggestions welcome.