### PR TITLE
[WIP] Add event beforeRouteChange to confirm whether or not we want to change routes 

### DIFF
--- a/Router.d.ts
+++ b/Router.d.ts
@@ -30,6 +30,17 @@ export interface RouteDetailLoaded extends RouteDetail {
      name: string
 }
 
+/** Detail object for the `beforeRouteChange` event */
+export interface BeforeRouteChange {
+    /** Location we would be leaving */
+    from: Location
+    /** Location we would be going to. This is may undefined in some cases, like if `pop` is used programmatically.*/
+    to?: Location
+
+    /** Would this event replace history? If false, it would push a new one, or alternatively go back in the history */
+    replace: boolean
+}
+
 /**
  * This is a Svelte component loaded asynchronously.
  * It's meant to be used with the `import()` function, such as `() => import('Foo.svelte')}`
@@ -200,6 +211,22 @@ export default class Router extends SvelteComponent {
          * and scroll to top on forward navigation.
          */
         restoreScrollState?: boolean
+        /**
+         * This function will be called before any attempt to go to another route.
+         * 
+         * If it returns false, then the route change is fully cancelled, and the current route and location
+         * stays the same. If it returns true, then the route change proceeds as usual.
+         * 
+         * By default, it returns a Promise of `true` immediatly, but you can adapt it to return false in certain
+         * scenarios where you do not want the user to leave from a page or go to a page.
+         * 
+         * # Note
+         * 
+         * It will **not** catch any history event manually sent by the browser, such as when the user clicks on
+         * the "back" button. `window.onpopstate` might be of some use for those kinds of cases, although
+         * it is limited.
+         */
+        beforeRouteChange?: (routeChange: BeforeRouteChange) => Promise<boolean>,
     }
 
     $on(event: 'routeEvent', callback: (event: CustomEvent) => void): () => void

--- a/test/app/src/App.svelte
+++ b/test/app/src/App.svelte
@@ -34,6 +34,7 @@
   on:routeLoaded={routeLoaded}
   on:routeLoading={routeLoading}
   on:routeEvent={routeEvent}
+  {beforeChangeRoute}
   {restoreScrollState}
 />
 
@@ -111,6 +112,11 @@ function conditionsFailed(event) {
 
     // Replace the route
     replace('/wild/conditions-failed')
+}
+
+function beforeChangeRoute(beforeChangeRoutePayload) {
+    console.log(beforeChangeRoutePayload)
+    return Promise.resolve(true)
 }
 
 // Handles the "routeLoaded" event dispatched by the router after a route has been successfully loaded


### PR DESCRIPTION
This is basically a shot at #204 , which is to add a function `beforeRouteChange` that may return true/false, if return false, prevent the history from being changed at all.

However I'm encountering a few problems, which is why it's still WIP. The biggest one:

Currently, in my implementation, `beforeRouteChange` is given to the `Router` component like so `<Router {routes} {beforeRouteChange} />`
But in the current codebase, `push` `link` `pop` are not in the component itself `<script>` but in the module part `<script context="module"`.
The problem is that in theory, I need to access `beforeRouteChange` in push to actually confirm we want to change the route
But it is not possible to call something from "module" to the component itself, because there might be multiple components of the same kind. However, in the case of router, it does not make much sense to have multiple `Router` instantiated at the same time (or does it? does anyone use 2 routers?).

The question is simple: what can I do to fix this?

For now, this doesn't compile, but you may have a look at the code to see how it looks and if there are improvements. I'm posting this here a bit early to try to solve how to fix this issue.