### PR TITLE
fix: restore router scroll state after route render

### DIFF
--- a/Router.svelte
+++ b/Router.svelte
@@ -478,12 +478,6 @@ $effect(() => {
     }
 })
 
-$effect(() => {
-    if (previousScrollState !== null) {
-        restoreScroll(previousScrollState)
-    }
-})
-
 async function dispatchNextTick(event, detail) {
     // Execute this code when the current call stack is complete
     await tick()
@@ -578,12 +572,20 @@ $effect(() => {
             })
 
             router._params = matchParams
+            if (restoreScrollState) {
+                restoreScroll(previousScrollState)
+                previousScrollState = null
+            }
             return
         }
 
         component = null
         componentObj = null
         router._params = undefined
+        if (restoreScrollState) {
+            restoreScroll(previousScrollState)
+            previousScrollState = null
+        }
     })
 
     return () => {


### PR DESCRIPTION
## Summary

This PR patches `svelte-spa-router@5.0.0` to fix scroll restoration timing when `restoreScrollState` is enabled.

The router restored scroll in a separate reactive effect as soon as the browser's history state changed. On back/forward navigation, that ran before the destination route had finished resolving and rendering causing unexpected scrolling issues.

## Bug

Users could lose their previous scroll position or see a jumpy transition when navigating back/forward between routes, because the router tried to restore scroll too early against the outgoing or not-yet-rendered page.

## Fix

The patch moves `restoreScroll(previousScrollState)` into the route resolution flow so it runs only after the matched route/component has been applied, and then clears the saved state.

## Impact

- Preserves scroll position reliably on browser back/forward
- Avoids restoring scroll against stale DOM
- Prevents duplicate restoration by clearing the saved state after use
