### PR TITLE
Transpile TypeScript to JavaScript in packaged Svelte components

### DIFF
--- a/.changeset/spa-router-ts-script-transpile.md
+++ b/.changeset/spa-router-ts-script-transpile.md
@@ -4,4 +4,4 @@
 
 fix: transpile TypeScript to JavaScript in packaged Svelte components
 
-The published `dist/Router.svelte` shipped its `<script>` blocks as raw TypeScript because no preprocessor was configured for `svelte-package`. Tools that parse the component script as JavaScript without first running the Svelte preprocessor (such as Vite 8's rolldown-based dependency optimizer) failed with a parse error on TypeScript-only syntax, e.g. the optional parameter in `link(node, opts?)`. A `svelte.config.js` using `vitePreprocess({script: true})` now transpiles the `<script>` blocks so packaged components contain plain JavaScript.
+The published `dist/Router.svelte` shipped its `<script>` blocks as raw TypeScript because no preprocessor was configured for `svelte-package`. A `svelte.config.js` using `vitePreprocess({script: true})` now transpiles the `<script>` blocks so packaged components contain plain JavaScript.

--- a/.changeset/spa-router-ts-script-transpile.md
+++ b/.changeset/spa-router-ts-script-transpile.md
@@ -1,0 +1,7 @@
+---
+'svelte-spa-router': patch
+---
+
+fix: transpile TypeScript to JavaScript in packaged Svelte components
+
+The published `dist/Router.svelte` shipped its `<script>` blocks as raw TypeScript because no preprocessor was configured for `svelte-package`. Tools that parse the component script as JavaScript without first running the Svelte preprocessor (such as Vite 8's rolldown-based dependency optimizer) failed with a parse error on TypeScript-only syntax, e.g. the optional parameter in `link(node, opts?)`. A `svelte.config.js` using `vitePreprocess({script: true})` now transpiles the `<script>` blocks so packaged components contain plain JavaScript.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "@changesets/cli": "^2.29.8",
         "@playwright/test": "^1.60.0",
         "@sveltejs/package": "^2.5.7",
+        "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tsconfig/svelte": "^5.0.8",
         "svelte": "^5.0.0",
         "svelte-check": "^4.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@sveltejs/package':
         specifier: ^2.5.7
         version: 2.5.7(svelte@5.55.5)(typescript@5.9.3)
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.0.0
+        version: 7.0.0(svelte@5.55.5)(vite@8.0.10)
       '@tsconfig/svelte':
         specifier: ^5.0.8
         version: 5.0.8

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,11 @@
+import {vitePreprocess} from '@sveltejs/vite-plugin-svelte'
+
+// `svelte-package` uses this config when building the `dist` output.
+// `script: true` transpiles the TypeScript in `.svelte` `<script>` blocks down
+// to plain JavaScript, so the published components don't ship TS-only syntax.
+// Without this, tools that parse the component script as JavaScript (such as
+// Vite 8's rolldown-based dependency optimizer) fail on TypeScript syntax like
+// the optional parameter in `link(node, opts?)`.
+export default {
+    preprocess: vitePreprocess({script: true})
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,11 +1,7 @@
 import {vitePreprocess} from '@sveltejs/vite-plugin-svelte'
 
 // `svelte-package` uses this config when building the `dist` output.
-// `script: true` transpiles the TypeScript in `.svelte` `<script>` blocks down
-// to plain JavaScript, so the published components don't ship TS-only syntax.
-// Without this, tools that parse the component script as JavaScript (such as
-// Vite 8's rolldown-based dependency optimizer) fail on TypeScript syntax like
-// the optional parameter in `link(node, opts?)`.
+// `script: true` transpiles the TypeScript in `.svelte` `<script>` blocks down to plain JavaScript, so the published components don't ship TS-only syntax.
 export default {
     preprocess: vitePreprocess({script: true})
 }


### PR DESCRIPTION
## Summary
Added a `svelte.config.js` configuration file to ensure TypeScript in Svelte component `<script>` blocks is transpiled to plain JavaScript when building the package distribution. This fixes compatibility issues with tools that parse component scripts as JavaScript without running the Svelte preprocessor.

## Changes
- **Added `svelte.config.js`**: Configured `vitePreprocess` with `script: true` to transpile TypeScript syntax in `<script>` blocks to JavaScript during the `svelte-package` build process
- **Added changeset**: Documented the fix for the patch release
- **Updated `package.json`**: Added `@sveltejs/vite-plugin-svelte` as a dev dependency to support the preprocessing configuration

## Implementation Details
The issue occurred because the published `dist/Router.svelte` contained raw TypeScript syntax (e.g., optional parameters like `link(node, opts?)`) in its `<script>` blocks. Tools like Vite 8's rolldown-based dependency optimizer that parse component scripts as JavaScript without first running the Svelte preprocessor would fail with parse errors on this TypeScript-only syntax.

By configuring `vitePreprocess({script: true})` in `svelte.config.js`, the build process now automatically transpiles all TypeScript in component scripts to plain JavaScript, ensuring the packaged components are compatible with downstream tools that don't run the Svelte preprocessor.

https://claude.ai/code/session_012NeCYzwFo983gbbaCJbw5M