### PR TITLE
chore: update hugo-assets to v0.1.0

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -4,4 +4,4 @@ go 1.26.3
 
 tool github.com/italypaleale/hugo-assets/cmd/vercel-docs-build
 
-require github.com/italypaleale/hugo-assets v0.0.0-20260625101919-30edcdce5680 // indirect
+require github.com/italypaleale/hugo-assets v0.1.0 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/italypaleale/hugo-assets v0.0.0-20260625101919-30edcdce5680 h1:/GMSKQmm9I7jDyVRkztGQHJ794W7EjV7nVEFgmqxoDk=
-github.com/italypaleale/hugo-assets v0.0.0-20260625101919-30edcdce5680/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=
+github.com/italypaleale/hugo-assets v0.1.0 h1:hydr1tFZd0Pgud7a45M+vwy7TQX1Gq2ek0oVMADBN6o=
+github.com/italypaleale/hugo-assets v0.1.0/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=


### PR DESCRIPTION
## Summary

This PR updates the pinned `github.com/italypaleale/hugo-assets` dependency in `docs/go.mod` from the pseudo-version `v0.0.0-20260625101919-30edcdce5680` to the tagged release `v0.1.0`.

## Changes

- `docs/go.mod`: updated `github.com/italypaleale/hugo-assets` from `v0.0.0-20260625101919-30edcdce5680` to `v0.1.0`
- `docs/go.sum`: updated checksums to match the new release

## Release details

- **New version:** `v0.1.0`
- **Release commit:** `58213d39f4c74fe91594935bd2065767c292da9d`
- **Repository:** https://github.com/italypaleale/hugo-assets

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkgWJRdHRaMGQpUzDNjcEw)_