### PR TITLE
chore: update hugo-assets to v0.3.0

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -11,5 +11,9 @@
   },
   "theme": {
     "scheme": "coral"
+  },
+  "robots": {
+    "llmsTXT": true,
+    "disallow": []
   }
 }

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -4,4 +4,4 @@ go 1.26.3
 
 tool github.com/italypaleale/hugo-assets/cmd/vercel-docs-build
 
-require github.com/italypaleale/hugo-assets v0.2.2 // indirect
+require github.com/italypaleale/hugo-assets v0.3.0 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/italypaleale/hugo-assets v0.2.2 h1:hm8DNxklpZvUnkirRdgCsCCndZ0P1Mp4dRGjWV5OqrY=
-github.com/italypaleale/hugo-assets v0.2.2/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=
+github.com/italypaleale/hugo-assets v0.3.0 h1:ZH7Tq0PZz3jOYYMddis6HxFuS9NEpKwO2ah8iNHjTe4=
+github.com/italypaleale/hugo-assets v0.3.0/go.mod h1:LPOrOBqvZgjTDNwInR/6mrKgbDndARoTo69TXvtAgu0=

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -3,8 +3,12 @@ baseURL = "https://svelte-spa-router.italypaleale.me/"
 locale = "en-us"
 title = "svelte-spa-router"
 disableKinds = ["rss"]
+enableRobotsTXT = true
 
 [module]
+  [module.hugoVersion]
+    extended = true
+    min = '0.164.0'
   [[module.imports]]
     path = "github.com/italypaleale/hugo-assets"
 
@@ -31,6 +35,9 @@ disableKinds = ["rss"]
   github_repo = "https://github.com/italypaleale/svelte-spa-router"
   github_branch = "main"
   PlausibleAnalytics = true
+
+  [params.robots]
+    llmsTXT = true
 
   [params.theme]
     scheme = "coral"


### PR DESCRIPTION
Updates the pinned `hugo-assets` dependency from `v0.2.2` to `v0.3.0` (commit `f87d1cda33dcf770bfc60b8b97d9bdec26055f95`).

## Changes

- `docs/go.mod` / `docs/go.sum`: bump `github.com/italypaleale/hugo-assets` to `v0.3.0`
- `docs/config.json`: add `robots` property (enables automatic `robots.txt` and `llms.txt` generation)
- `docs/hugo.toml`: regenerated — adds `enableRobotsTXT = true`, `[module.hugoVersion]`, and `[params.robots]`

## Release notes (hugo-assets v0.3.0)

> This release adds automatic generation of `robots.txt` and `llms.txt`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011i23osEpnby99wm56BLasM)_